### PR TITLE
Removing tabs sometimes didn't work

### DIFF
--- a/lib/components/tabsx/tabsx.dart
+++ b/lib/components/tabsx/tabsx.dart
@@ -53,7 +53,7 @@ class Tabsx implements OnInit {
           : index + 1;
       tabs [ newActiveIndex ].active = true;
     }
-    slice(tabs, index, 1);
+    tabs.remove(tabs);
   }
 }
 

--- a/lib/components/tabsx/tabsx.dart
+++ b/lib/components/tabsx/tabsx.dart
@@ -53,7 +53,7 @@ class Tabsx implements OnInit {
           : index + 1;
       tabs [ newActiveIndex ].active = true;
     }
-    tabs.remove(tabs);
+    tabs.remove(tab);
   }
 }
 


### PR DESCRIPTION
When destroying an angular father component, the child tabsx component sometimes bug because it didn't found the index in the slice function.
With replacing the slice function by the remove method of the List object, there is no more bugs.
