### PR TITLE
 v0.3.0+1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.3.0+1
+
+* use `sass_transformer 0.1.0` instead `dart-sass 0.5.0`
+* remove packages path from `all.scss`
+
 ## v0.3.0
 
 * Rename components to use pattern `Bs<name>Component`

--- a/lib/all.scss
+++ b/lib/all.scss
@@ -1,8 +1,8 @@
-@import "packages/bootstrap_sass/scss/bootstrap";
-@import "packages/ng_bootstrap/components/progress/progress";
-@import "packages/ng_bootstrap/components/tooltip/tooltip";
-@import "packages/ng_bootstrap/components/button/button_group";
-@import "packages/ng_bootstrap/components/dropdown/dropdown";
-@import "packages/ng_bootstrap/components/accordion/panels";
-@import "packages/ng_bootstrap/components/pagination/pagination";
-@import "packages/ng_bootstrap/components/pagination/pager";
+@import "../packages/bootstrap_sass/scss/bootstrap";
+@import "components/progress/progress";
+@import "components/tooltip/tooltip";
+@import "components/button/button_group";
+@import "components/dropdown/dropdown";
+@import "components/accordion/panels";
+@import "components/pagination/pagination";
+@import "components/pagination/pager";

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ng_bootstrap
-version: 0.3.0
+version: 0.3.0+1
 description: Angular 2 and Bootstrap 4
 authors:
   - Luis Vargas <luisvargastijerino@gmail.com>
@@ -14,14 +14,15 @@ dependencies:
   intl: ^0.13.0
   dart_to_js_script_rewriter: ^1.0.1
   markdown: ^0.8.0
-  sass: ^0.4.2
-  bootstrap_sass: ^4.0.0-alpha.3+1
+  bootstrap_sass: ^4.0.0-alpha.3+2
   stream_transformers: ^0.3.0+3
   font_awesome: ^4.6.3
   dson: ^0.3.4
   reflectable: ^0.5.4
+dev_dependencies:
+  sass_transformer: ^0.1.0
 transformers:
-- sass
+- sass_transformer
 - angular2:
     platform_directives:
     - package:angular2/common.dart#COMMON_DIRECTIVES


### PR DESCRIPTION
- use `sass_transformer 0.1.0` instead `dart-sass 0.5.0`
- remove packages path from `all.scss`
